### PR TITLE
Feature: Define custom multiple default theme options using an Array

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ exports.decorateConfig = config => {
 	let theme;
 	let keys;
 	let index;
-	let pokemonTheme = config.pokemon.toLowerCase();
+	let pokemonTheme = Array.isArray(config.pokemon)?config.pokemon[Math.floor(Math.random()*config.pokemon.length)]:config.pokemon.toLowerCase();
+
 	const unibody = config.unibody;
 	const unibodyFlag = unibody !== 'false';
 


### PR DESCRIPTION
I wanted to get a random pokemon chosen between a few that I like, so I thought about this little enhancement.
This way you can set the "pokemon" option in hyper config to something like
`pokemon: ['mewtwo', 'zapdos', 'moltres', 'articuno', 'pikachu', 'raichu', 'charizard', 'mew']`
or even
`pokemon: ['pikachu', 'random']`
for a 50% of getting a pikachu.


What do you think?