### PR TITLE
Remove white top-border from header when maximizing Hyper

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,9 @@ exports.decorateConfig = config => {
       .header_header, .header_windowHeader {
         background-color: ${background} !important;
       }
+     .hyper_main {
+        background-color: ${background};
+      }
       .tab_textActive .tab_textInner::before {
         content: url("file://${tabContent}");
         position: absolute;


### PR DESCRIPTION
when maximizing the window on Windows 10, there is a one-pixel white border around the header. so I add the `.hyper_main` in line 135.

<!--

Thank you for taking the time to contribute to Hyper Pokémon 🎉

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klauscfhq/hyper-pokemon/blob/master/contributing.md).

If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage.

-->
