### PR TITLE
Define highlight colors depending on the secondary color

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,10 @@ exports.decorateConfig = config => {
   const selection = color(primary).alpha(0.3).string();
   const transparent = color(secondary).alpha(0).string();
   const header = color(background).isDark() ? '#FAFAFA' : '#010101';
-  const activeTab = color(secondary).isDark() ? '#FAFAFA' : '#383A42';
+  const isSecondaryDark = color(secondary).isDark();
+  const activeTab = isSecondaryDark ? '#FAFAFA' : '#383A42';
+  const highlight = isSecondaryDark ? '#FFFFFF' : '#000000';
+  const secondHighlight = isSecondaryDark ? '#C7C7C7' : '#686868';
   const tab = color(activeTab).darken(0.1);
 
   // Set poketab
@@ -106,7 +109,7 @@ exports.decorateConfig = config => {
       blue: secondary,
       magenta: secondary,
       cyan: secondary,
-      white: secondary,
+      white: secondHighlight,
       lightBlack: tertiary,
       lightRed: secondary,
       lightGreen: secondary,
@@ -114,7 +117,7 @@ exports.decorateConfig = config => {
       lightBlue: secondary,
       lightMagenta: secondary,
       lightCyan: secondary,
-      lightWhite: secondary
+      lightWhite: highlight
     }
   };
 


### PR DESCRIPTION
Hi, thank you for your work! I'm really enjoying this plugin and I'd be glad if I can help to make it better 😃 

## Issue
When I do `ls | grep something` and also when vim shows an alert message,
output text is not readable since the font color is the same as the background.

macOS
hyper version: 2.0.0
hyper-pokemon version: 0.4.3

![screenshot 2018-08-22 14 24 46](https://user-images.githubusercontent.com/10802891/44465025-5304f700-a657-11e8-8c03-0a8dab4caea8.png)

![screenshot 2018-08-22 14 27 18](https://user-images.githubusercontent.com/10802891/44465048-5e582280-a657-11e8-849f-2706d02caf90.png)


## What I did
I added constants `highlight` and `secondHighlight`, and set them to `lightWhite` and `white` respectively. The constants are defined depending on the value of `secondary`. When secondary is a dark color, highlight colors will be white, otherwise black.  I chose `#000000` and `#FFFFFF` for lightWhite, and `#686868` and `#C7C7C7` for white because those are default colors in `.hyper.js` and easy to recognize. I've checked almost all themes.

![screenshot 2018-08-22 22 18 00](https://user-images.githubusercontent.com/10802891/44465705-4f726f80-a659-11e8-92db-5ab96ba85933.png)

![screenshot 2018-08-22 22 13 53](https://user-images.githubusercontent.com/10802891/44465575-f4d91380-a658-11e8-9d45-7e032b4973ba.png)
