### PR TITLE
Update store link in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ The poll will be kept alive until the project's completion, when all **600+** th
 
 ### Hyper Store
 
-Get the theme on the official [Hyper Store](https://hyper.is/plugins/hyper-pokemon).
+Get the theme on the official [Hyper Store](https://hyper.is/store/hyper-pokemon).
 
 ### Using the plugin manager - `hyper`
 


### PR DESCRIPTION
<!--

Thank you for taking the time to contribute to Hyper Pokémon 🎉

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klaussinani/hyper-pokemon/blob/master/contributing.md).

If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage.

-->

It seems that the Hyper store has changed the way their sub-pages are organized, so the original store link fails. I've added the updated link.
